### PR TITLE
add cluster name variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,18 @@ Simple YARN application to run n copies of a unix command - deliberately kept si
 
 Usage:
 ======
+$cluster_name=$(hdfs getconf -confKey fs.defaultFS) 
+
+$sample_command=$(which date)
 
 ### Unmanaged mode
 
-$ bin/hadoop jar $HADOOP_YARN_HOME/share/hadoop/yarn/hadoop-yarn-applications-unmanaged-am-launcher-2.1.1-SNAPSHOT.jar Client -classpath simple-yarn-app-1.0-SNAPSHOT.jar -cmd "java com.hortonworks.simpleyarnapp.ApplicationMaster /bin/date 2"
+$ bin/hadoop jar $HADOOP_YARN_HOME/share/hadoop/yarn/hadoop-yarn-applications-unmanaged-am-launcher-2.1.1-SNAPSHOT.jar Client -classpath simple-yarn-app-1.0-SNAPSHOT.jar -cmd "java com.hortonworks.simpleyarnapp.ApplicationMaster $sample_command 2"
 
 ### Managed mode
 
-$ bin/hadoop fs -copyFromLocal simple-yarn-app-1.0-SNAPSHOT.jar /apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
+$ bin/hadoop fs -copyFromLocal simple-yarn-app-1.0-SNAPSHOT.jar $cluster_name/apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
 
-$ bin/hadoop jar simple-yarn-app-1.0-SNAPSHOT.jar com.hortonworks.simpleyarnapp.Client /bin/date 2 /apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
-  
+$ bin/hadoop jar simple-yarn-app-1.0-SNAPSHOT.jar com.hortonworks.simpleyarnapp.Client $sample_command 2 $cluster_name/apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
+
     

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ $ bin/hadoop jar $HADOOP_YARN_HOME/share/hadoop/yarn/hadoop-yarn-applications-un
 
 ### Managed mode
 
-$ bin/hadoop fs -copyFromLocal simple-yarn-app-1.0-SNAPSHOT.jar $cluster_name/apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
+$ bin/hadoop fs -copyFromLocal simple-yarn-app-1.0-SNAPSHOT.jar $cluster_name/apps/simple/simple-yarn-app-1.1.0.jar
 
-$ bin/hadoop jar simple-yarn-app-1.0-SNAPSHOT.jar com.hortonworks.simpleyarnapp.Client $sample_command 2 $cluster_name/apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
+$ bin/hadoop jar simple-yarn-app-1.0-SNAPSHOT.jar com.hortonworks.simpleyarnapp.Client $sample_command 2 $cluster_name/apps/simple/simple-yarn-app-1.1.0.jar
 
     


### PR DESCRIPTION
To make the Readme.md more readable, cluster name variable was added to avoid the common failure.