### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ $ bin/hadoop jar $HADOOP_YARN_HOME/share/hadoop/yarn/hadoop-yarn-applications-un
 
 $ bin/hadoop fs -copyFromLocal simple-yarn-app-1.0-SNAPSHOT.jar /apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
 
-$ bin/hadoop jar simple-yarn-app-1.0-SNAPSHOT.jar com.hortonworks.simpleyarnapp.Client /bin/date 2 /apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
+$ bin/hadoop jar simple-yarn-app-1.0-SNAPSHOT.jar com.hortonworks.simpleyarnapp.Client /bin/date 2 hdfs://apps/simple/simple-yarn-app-1.0-SNAPSHOT.jar
   
     


### PR DESCRIPTION
Add hdfs:// prefixe for jar path.

Seems that many people encountered the issue metioned in below link:
https://github.com/hortonworks/simple-yarn-app/issues/4
My internal cluster is CDH5.4.0 and I have same issue.